### PR TITLE
Update elements.css

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -146,7 +146,7 @@
 /* Blockquote */
 
 blockquote,
-.blockquote {
+div.blockquote {
 	--box-shadow: rgba(var(--swatch-menubg-black-color), 0.1);
 	display: block;
 	border-style: dashed;


### PR DESCRIPTION
Sigma-9 defines its fake blockquotes with the `div.blockquote` selector, which causes BHL's fake blockquotes (defined with `.blockquote`) to be treated as less specific, and get overrode. This moves .blockquote to div.blockquote to prevent this issue.