### PR TITLE
Remove exception for -CN series sidebar links

### DIFF
--- a/src/css/int/chn/black-highlighter_ch.css
+++ b/src/css/int/chn/black-highlighter_ch.css
@@ -1703,14 +1703,6 @@
         padding-right: 3em;
     }
 
-    #side-bar div.menu-item img[src*="scp-wiki-cn.wikidot"] + a[href*="scp-series"] {
-        text-align: left;
-        align-items: flex-start;
-        flex-grow: 0;
-        width: auto;
-        min-width: 45%;
-    }
-
     #side-bar div.collapsible-block {
         text-align: right;
         flex-basis: 100%;


### PR DESCRIPTION
Sekai notified me that, per an update to the -CN sidebar, an exception that was previously made for it is no longer required and is now causing issues:

<img src="https://media.discordapp.net/attachments/669352764111061002/719343618048917574/image0.png" height="300">

<img src="https://cdn.discordapp.com/attachments/669352764111061002/719343645240852500/image0.png" height="300">