### PR TITLE
div.blockquote

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -146,7 +146,7 @@
 /* Blockquote */
 
 blockquote,
-.blockquote {
+div.blockquote {
 	--box-shadow: rgba(var(--swatch-menubg-black-color), 0.1);
 	display: block;
 	border-style: dashed;
@@ -698,7 +698,7 @@ table.wiki-content-table tr {
 	}
 
 	blockquote,
-	.blockquote {
+	div.blockquote {
 		margin-left: 0;
 		margin-right: 0;
 	}


### PR DESCRIPTION
Currently, elements.css uses `.blockquote` to define the rules for the "blockquote" class. However, Sigma-9 defines this class with `div.blockquote`, which is a higher selector. This causes the Sigma-9 rules for the class to override the Black Highlighter rules, such as color and margin. By matching the selectors, the BHL CSS will continue to display.