### PR TITLE
Fix Edit History Stack

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -727,6 +727,12 @@ textarea,
 	max-width: 100%;
 }
 
+/* Edit History Styling */
+
+table.page-history tr td:nth-of-type(2) input {
+     width: initial;
+}
+
 /* Edit Area Styling */
 
 table.form {


### PR DESCRIPTION
Currently, the buttons to select a version in the edit history are forced into a vertical stack, which makes it significantly more difficult to find the correct version and compare pages that use Black Highlighter. This is from the following line in `structure.css`:

```css
table:not(.form) td>input {
    width: 100%;
}
```

I have found a selector that specifically affects the edit history buttons, and puts the two buttons side-by-side, as they should be, by removing the `width: 100%` argument that caused the issue.