### PR TITLE
Update normalize.css to match Sigma-9

### DIFF
--- a/src/css/normalize.css
+++ b/src/css/normalize.css
@@ -1106,7 +1106,7 @@ table,#page-content div,
 	#navi-bar-shadow {
 		display: inherit;
 	}
-	.open-menu a {
+	#top-bar .open-menu a {
 		position: inherit;
 		top: inherit;
 		left: inherit;
@@ -1124,7 +1124,7 @@ table,#page-content div,
 		border-radius: inherit;
 		color: inherit;
 	}
-	.open-menu a:hover {
+	#top-bar .open-menu a:hover {
 		text-decoration: inherit;
 		-webkit-box-shadow: inherit;
 		box-shadow: inherit;


### PR DESCRIPTION
I pushed an update to the selectors used to affect the burger menu on the mobile version of Sigma-9 earlier today. This causes the segments of normalize.css that affected the burger menu to no longer apply. This change matches the selectors between normalize.css and Sigma-9 and should undo the fix. BHL uses different selectors than Sigma-9 for this element, and no further change is needed other than to normalize.css.