### PR TITLE
Increase Hovertip Width

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -196,7 +196,7 @@ div.blockquote {
 
 
 .hovertip {
-	width: 15% !important;
+	width: 25% !important;
 	opacity: 0;
 	animation-name: fade-in;
 	animation-duration: 600ms;


### PR DESCRIPTION
The current width size for .hovertip elements is too narrow, and often causes long footnotes to overflow off the page length. 

[An example of this happening on SCP-3812.](https://cdn.discordapp.com/attachments/719921904991076462/799420816416702464/unknown.png) (Note that this specific footnote does barely fit on the screen in question, but it not easily readable or easy to make it display.)

Increasing the width of the hovertips to 25% will help alleviate this issue and allow longer footnotes to be read on desktop.