### PR TITLE
Split out Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ MAKEFLAGS += --no-builtin-rules
 .PHONY: images css css-int files legacy
 .PHONY: clean
 
+# Default rule
+default: images css css-int files legacy
+
 include build/meta.mk
 include build/css.mk
 include build/images.mk
@@ -13,112 +16,10 @@ include build/int.mk
 include build/legacy.mk
 
 # Top-level rules
-default: images css css-int files legacy
-
 css: dist/css/min/ $(CSS_OUTPUTS) $(INT_OUTPUTS)
 images: dist/img/ $(IMAGE_OUTPUTS)
 files: $(FILES_OUTPUTS)
 legacy: dist/stable/styles/ $(LEGACY_CSS_OUTPUTS)
-
-# Directory creation
-dist/%/:
-	mkdir -p $@
-
-# npm rules
-node_modules: package.json package-lock.json
-	npm install
-	touch node_modules
-
-# CSS rules
-dist/css/black-highlighter.css: src/css/black-highlighter.css $(BUILD_SOURCES) $(CSS_SOURCES) node_modules
-	npm run postcss -- --config build/css-merge -o $@ $<
-	cat \
-		src/css/black-highlighter-wrap-begin.css \
-		$@ \
-		src/css/black-highlighter-wrap-close.css \
-			> $@_
-	mv $@_ $@
-
-dist/css/min/black-highlighter.min.css: dist/css/black-highlighter.css node_modules
-	npm run postcss -- --config build/css-minify -o $@ $<
-
-dist/css/normalize.css: src/css/normalize.css $(BUILD_SOURCES) src/css/normalize-wrap-begin.css src/css/normalize-wrap-close.css
-	cat \
-		src/css/normalize-wrap-begin.css \
-		$< \
-		src/css/normalize-wrap-close.css \
-			> $@
-
-dist/css/min/normalize.min.css: dist/css/normalize.css node_modules
-	npm run postcss -- --config build/css-minify -o $@ $<
-
-# INT rules
-# Copied from above
-#
-# This does not actually use Makefile's template system since
-# you can't have something be both a prerequisite and
-# dynamically generated unfortunately.
-
-# CN - Chinese Branch
-INT_SOURCES_CN := $(wildcard src/css/int/cn/*.patch)
-INT_OUTPUTS_CN := \
-	dist/css/int/cn/black-highlighter.css \
-	dist/css/int/cn/normalize.css \
-	dist/css/int/cn/min/black-highlighter.min.css \
-	dist/css/int/cn/min/normalize.min.css
-
-dist/css/int/cn/black-highlighter.css dist/css/int/cn/normalize.css: $(INT_SOURCES_CN)
-	build/int-patch-and-merge.sh cn
-
-dist/css/int/cn/min/black-highlighter.min.css: dist/css/int/cn/black-highlighter.css
-	npm run postcss -- --config build/css-minify -o $@ $<
-
-dist/css/int/cn/min/normalize.min.css: dist/css/int/cn/normalize.css
-	npm run postcss -- --config build/css-minify -o $@ $<
-
-# TEST - Sample / Test of INT capabilities
-INT_SOURCES_TEST := $(wildcard src/css/int/test/*.patch)
-INT_OUTPUTS_TEST := \
-	dist/css/int/test/black-highlighter.css \
-	dist/css/int/test/normalize.css \
-	dist/css/int/test/min/black-highlighter.min.css \
-	dist/css/int/test/min/normalize.min.css
-
-dist/css/int/test/black-highlighter.css dist/css/int/test/normalize.css: $(INT_SOURCES_TEST)
-	build/int-patch-and-merge.sh cn
-
-dist/css/int/test/min/black-highlighter.min.css: dist/css/int/text/black-highlighter.css
-	npm run postcss -- --config build/css-minify -o $@ $<
-
-dist/css/int/test/min/normalize.min.css: dist/css/int/test/normalize.css
-	npm run postcss -- --config build/css-minify -o $@ $<
-
-# Legacy symlinks for stable/styles CSS
-dist/stable/styles/DEPRECATED: src/misc/legacy-deprecation-notice.txt
-	install -D -m444 $< $@
-
-dist/stable/styles/black-highlighter.min.css:
-	cd $(@D); ln -sf ../../css/min/$(@F)
-
-dist/stable/styles/normalize.min.css:
-	cd $(@D); ln -sf ../../css/min/$(@F)
-
-# Image optimization
-dist/img/%.gif: src/img/%.gif node_modules
-	npm run optimize -- gif $< $@
-
-dist/img/%.png: src/img/%.png node_modules
-	npm run optimize -- png $< $@
-
-dist/img/%.svg: src/img/%.svg node_modules
-	npm run optimize -- svg $< $@
-
-# Static files
-dist/spherical/domicile.html: src/misc/domicile.html
-	install -D -m644 $< $@
-
-dist/%.html: src/root/%.html
-	install -D -m644 $< $@
 
 # Utility rules
 clean:

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ MAKEFLAGS += --no-builtin-rules
 # Default rule
 default: images css css-int files legacy
 
+# Sub-makefiles included
 include build/meta.mk
 include build/css.mk
 include build/images.mk

--- a/Makefile
+++ b/Makefile
@@ -5,72 +5,12 @@ MAKEFLAGS += --no-builtin-rules
 .PHONY: images css css-int files legacy
 .PHONY: clean
 
-# Fields
-BUILD_SOURCES := \
-	$(wildcard build/**/*) \
-	cssnano.config.js
-
-CSS_SOURCES   := $(wildcard src/css/*.css)
-CSS_OUTPUTS   := \
-	dist/css/min/black-highlighter.min.css \
-	dist/css/min/normalize.min.css
-
-IMAGE_SOURCES := $(wildcard src/img/*)
-IMAGE_OUTPUTS := $(patsubst src/img/%,dist/img/%,$(IMAGE_SOURCES))
-
-FILES_SOURCES := \
-	src/misc/domicile.html \
-	src/root/index.html \
-	src/root/error.html
-FILES_OUTPUTS := \
-	dist/spherical/domicile.html \
-	dist/index.html \
-	dist/error.html
-
-# Dynamic patching and building for any INT directories present
-INT_BRANCHES  := \
-	cn \
-	test
-
-INT_SOURCES   := \
-	$(INT_SOURCES_CN) \
-	$(INT_SOURCES_TEST)
-
-INT_OUTPUTS   := \
-	$(INT_OUTPUTS_CN) \
-	$(INT_OUTPUTS_TEST)
-
-INT_DIRS      := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
-
-ifneq ($(INT_BRANCHES), $(INT_DIRS))
-	$(error Declared list of branches doesn't match directory!)
-endif
-
-# Template for creating rules for new branches
-
-define INT_BRANCHES_template =
-INT_SOURCES_$(1) := $(wildcard src/css/int/$(1)/*.patch)
-INT_OUTPUTS_$(1) := \
-	dist/css/int/$(1)/black-highlighter.css \
-	dist/css/int/$(1)/normalize.css \
-	dist/css/int/$(1)/min/black-highlighter.min.css \
-	dist/css/int/$(1)/min/normalize.min.css
-
-dist/css/int/$(1)/black-highlighter.css dist/css/int/$(1)/normalize.css: $(INT_SOURCES_$(1))
-	build/int-patch-and-merge.sh $(1)
-
-dist/css/int/$(1)/min/black-highlighter.min.css: dist/css/int/$(1)/black-highlighter.css
-	npm run postcss -- --config build/css-minify -o $$@ $$<
-
-dist/css/int/$(1)/min/normalize.min.css: dist/css/int/$(1)/normalize.css
-	npm run postcss -- --config build/css-minify -o $$@ $$<
-endef
-
-LEGACY_CSS_SOURCES :=
-LEGACY_CSS_OUTPUTS := \
-	dist/stable/styles/DEPRECATED \
-	dist/stable/styles/black-highlighter.min.css \
-	dist/stable/styles/normalize.min.css
+include build/meta.mk
+include build/css.mk
+include build/images.mk
+include build/files.mk
+include build/int.mk
+include build/legacy.mk
 
 # Top-level rules
 default: images css css-int files legacy

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,15 @@ FILES_OUTPUTS := \
 	dist/error.html
 
 # Dynamic patching and building for any INT directories present
-INT_BRANCHES  := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
-INT_SOURCES   := $(wildcard src/css/int/**/*)
+INT_BRANCHES  := \
+	cn \
+	test
+
+INT_DIRS      := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
+
+ifneq ($(INT_BRANCHES), $(INT_DIRS))
+	$(error Declared list of branches doesn't match directory!)
+endif
 
 define INT_BRANCHES_template =
 INT_SOURCES_$(1) := $(wildcard src/css/int/$(1)/*.patch)

--- a/README.md
+++ b/README.md
@@ -30,4 +30,13 @@ However (for obvious reasons) `make` cannot determine if `node_modules` has all 
 
 Additionally, you can run `make -B` to force re-building all targets, or `make clean` to dispose of the `/dist` directory.
 
-Note: due to some issues with make's dynamic rule ordering, it may be necessary to `make -B css-int` to force rebuild of INT variants.
+### Adding a new branch variant
+
+If you wish to add a new INT branch variant, there are a few things that you must do:
+
+* Create a directory in `src/css/int/` corresponding to the branch name.
+* Add this name to `INT_BRANCHES` in `build/int.mk`.
+* Create a `build/int-xxx.mk` file (where `xxx` is the branch name) with contents copied from the template provided. Compare with the existing INT files to ensure it is correct.
+* Add `$(INT_SOURCES_XXX)` and `$(INT_OUTPUTS_XXX)` to `INT_SOURCES` and `INT_OUTPUTS`, respectively.
+* Add your patch files, as appropriate.
+* Test the build process, and ensure the output matches what you expect.

--- a/build/css.mk
+++ b/build/css.mk
@@ -1,0 +1,4 @@
+CSS_SOURCES   := $(wildcard src/css/*.css)
+CSS_OUTPUTS   := \
+	dist/css/min/black-highlighter.min.css \
+	dist/css/min/normalize.min.css

--- a/build/css.mk
+++ b/build/css.mk
@@ -1,4 +1,28 @@
+# Variables
 CSS_SOURCES   := $(wildcard src/css/*.css)
 CSS_OUTPUTS   := \
 	dist/css/min/black-highlighter.min.css \
 	dist/css/min/normalize.min.css
+
+# CSS rules
+dist/css/black-highlighter.css: src/css/black-highlighter.css $(BUILD_SOURCES) $(CSS_SOURCES) node_modules
+	npm run postcss -- --config build/css-merge -o $@ $<
+	cat \
+		src/css/black-highlighter-wrap-begin.css \
+		$@ \
+		src/css/black-highlighter-wrap-close.css \
+			> $@_
+	mv $@_ $@
+
+dist/css/min/black-highlighter.min.css: dist/css/black-highlighter.css node_modules
+	npm run postcss -- --config build/css-minify -o $@ $<
+
+dist/css/normalize.css: src/css/normalize.css $(BUILD_SOURCES) src/css/normalize-wrap-begin.css src/css/normalize-wrap-close.css
+	cat \
+		src/css/normalize-wrap-begin.css \
+		$< \
+		src/css/normalize-wrap-close.css \
+			> $@
+
+dist/css/min/normalize.min.css: dist/css/normalize.css node_modules
+	npm run postcss -- --config build/css-minify -o $@ $<

--- a/build/css.mk
+++ b/build/css.mk
@@ -1,6 +1,6 @@
 # Variables
-CSS_SOURCES   := $(wildcard src/css/*.css)
-CSS_OUTPUTS   := \
+CSS_SOURCES := $(wildcard src/css/*.css)
+CSS_OUTPUTS := \
 	dist/css/min/black-highlighter.min.css \
 	dist/css/min/normalize.min.css
 

--- a/build/files.mk
+++ b/build/files.mk
@@ -1,0 +1,9 @@
+
+FILES_SOURCES := \
+	src/misc/domicile.html \
+	src/root/index.html \
+	src/root/error.html
+FILES_OUTPUTS := \
+	dist/spherical/domicile.html \
+	dist/index.html \
+	dist/error.html

--- a/build/files.mk
+++ b/build/files.mk
@@ -1,4 +1,4 @@
-
+# Variables
 FILES_SOURCES := \
 	src/misc/domicile.html \
 	src/root/index.html \
@@ -7,3 +7,10 @@ FILES_OUTPUTS := \
 	dist/spherical/domicile.html \
 	dist/index.html \
 	dist/error.html
+
+# Static files
+dist/spherical/domicile.html: src/misc/domicile.html
+	install -D -m644 $< $@
+
+dist/%.html: src/root/%.html
+	install -D -m644 $< $@

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,3 +1,13 @@
-
+# Variables
 IMAGE_SOURCES := $(wildcard src/img/*)
 IMAGE_OUTPUTS := $(patsubst src/img/%,dist/img/%,$(IMAGE_SOURCES))
+
+# Image optimization
+dist/img/%.gif: src/img/%.gif node_modules
+	npm run optimize -- gif $< $@
+
+dist/img/%.png: src/img/%.png node_modules
+	npm run optimize -- png $< $@
+
+dist/img/%.svg: src/img/%.svg node_modules
+	npm run optimize -- svg $< $@

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,0 +1,3 @@
+
+IMAGE_SOURCES := $(wildcard src/img/*)
+IMAGE_OUTPUTS := $(patsubst src/img/%,dist/img/%,$(IMAGE_SOURCES))

--- a/build/int-cn.mk
+++ b/build/int-cn.mk
@@ -1,6 +1,7 @@
 # CN - Chinese Branch
 INT_SOURCES_CN := $(wildcard src/css/int/cn/*.patch)
 INT_OUTPUTS_CN := \
+	dist/css/int/cn/ \
 	dist/css/int/cn/black-highlighter.css \
 	dist/css/int/cn/normalize.css \
 	dist/css/int/cn/min/black-highlighter.min.css \

--- a/build/int-cn.mk
+++ b/build/int-cn.mk
@@ -1,0 +1,16 @@
+# CN - Chinese Branch
+INT_SOURCES_CN := $(wildcard src/css/int/cn/*.patch)
+INT_OUTPUTS_CN := \
+	dist/css/int/cn/black-highlighter.css \
+	dist/css/int/cn/normalize.css \
+	dist/css/int/cn/min/black-highlighter.min.css \
+	dist/css/int/cn/min/normalize.min.css
+
+dist/css/int/cn/black-highlighter.css dist/css/int/cn/normalize.css: $(INT_SOURCES_CN)
+	build/int-patch-and-merge.sh cn
+
+dist/css/int/cn/min/black-highlighter.min.css: dist/css/int/cn/black-highlighter.css
+	npm run postcss -- --config build/css-minify -o $@ $<
+
+dist/css/int/cn/min/normalize.min.css: dist/css/int/cn/normalize.css
+	npm run postcss -- --config build/css-minify -o $@ $<

--- a/build/int-template.mk
+++ b/build/int-template.mk
@@ -1,0 +1,27 @@
+# Template for creating rules for new branches
+#
+# This template isn't directly used!
+#
+# Because Makefile can't have something both as a dynamic
+# list and as requisites we're just copying and pasting
+# these rules.
+#
+# There aren't many INT branches so this isn't too terrible.
+
+define INT_BRANCHES_template =
+INT_SOURCES_$(1) := $(wildcard src/css/int/$(1)/*.patch)
+INT_OUTPUTS_$(1) := \
+	dist/css/int/$(1)/black-highlighter.css \
+	dist/css/int/$(1)/normalize.css \
+	dist/css/int/$(1)/min/black-highlighter.min.css \
+	dist/css/int/$(1)/min/normalize.min.css
+
+dist/css/int/$(1)/black-highlighter.css dist/css/int/$(1)/normalize.css: $(INT_SOURCES_$(1))
+	build/int-patch-and-merge.sh $(1)
+
+dist/css/int/$(1)/min/black-highlighter.min.css: dist/css/int/$(1)/black-highlighter.css
+	npm run postcss -- --config build/css-minify -o $$@ $$<
+
+dist/css/int/$(1)/min/normalize.min.css: dist/css/int/$(1)/normalize.css
+	npm run postcss -- --config build/css-minify -o $$@ $$<
+endef

--- a/build/int-test.mk
+++ b/build/int-test.mk
@@ -8,7 +8,7 @@ INT_OUTPUTS_TEST := \
 	dist/css/int/test/min/normalize.min.css
 
 dist/css/int/test/black-highlighter.css dist/css/int/test/normalize.css: $(INT_SOURCES_TEST)
-	build/int-patch-and-merge.sh cn
+	build/int-patch-and-merge.sh test
 
 dist/css/int/test/min/black-highlighter.min.css: dist/css/int/test/black-highlighter.css
 	npm run postcss -- --config build/css-minify -o $@ $<

--- a/build/int-test.mk
+++ b/build/int-test.mk
@@ -1,6 +1,7 @@
 # TEST - Sample / Test of INT capabilities
 INT_SOURCES_TEST := $(wildcard src/css/int/test/*.patch)
 INT_OUTPUTS_TEST := \
+	dist/css/int/test/ \
 	dist/css/int/test/black-highlighter.css \
 	dist/css/int/test/normalize.css \
 	dist/css/int/test/min/black-highlighter.min.css \

--- a/build/int-test.mk
+++ b/build/int-test.mk
@@ -1,0 +1,16 @@
+# TEST - Sample / Test of INT capabilities
+INT_SOURCES_TEST := $(wildcard src/css/int/test/*.patch)
+INT_OUTPUTS_TEST := \
+	dist/css/int/test/black-highlighter.css \
+	dist/css/int/test/normalize.css \
+	dist/css/int/test/min/black-highlighter.min.css \
+	dist/css/int/test/min/normalize.min.css
+
+dist/css/int/test/black-highlighter.css dist/css/int/test/normalize.css: $(INT_SOURCES_TEST)
+	build/int-patch-and-merge.sh cn
+
+dist/css/int/test/min/black-highlighter.min.css: dist/css/int/text/black-highlighter.css
+	npm run postcss -- --config build/css-minify -o $@ $<
+
+dist/css/int/test/min/normalize.min.css: dist/css/int/test/normalize.css
+	npm run postcss -- --config build/css-minify -o $@ $<

--- a/build/int-test.mk
+++ b/build/int-test.mk
@@ -9,7 +9,7 @@ INT_OUTPUTS_TEST := \
 dist/css/int/test/black-highlighter.css dist/css/int/test/normalize.css: $(INT_SOURCES_TEST)
 	build/int-patch-and-merge.sh cn
 
-dist/css/int/test/min/black-highlighter.min.css: dist/css/int/text/black-highlighter.css
+dist/css/int/test/min/black-highlighter.min.css: dist/css/int/test/black-highlighter.css
 	npm run postcss -- --config build/css-minify -o $@ $<
 
 dist/css/int/test/min/normalize.min.css: dist/css/int/test/normalize.css

--- a/build/int.mk
+++ b/build/int.mk
@@ -1,20 +1,11 @@
-
-# Dynamic patching and building for any INT directories present
+# Static declaration of INT branches available
 INT_BRANCHES  := \
 	cn \
 	test
 
-INT_SOURCES   := \
-	$(INT_SOURCES_CN) \
-	$(INT_SOURCES_TEST)
-
-INT_OUTPUTS   := \
-	$(INT_OUTPUTS_CN) \
-	$(INT_OUTPUTS_TEST)
-
 INT_DIRS      := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
 
-# Assert that the directories in INT match the constant list.
+# Assert that the directories in INT match the constant list
 ifneq ($(INT_BRANCHES), $(INT_DIRS))
 	$(error Declared list of branches doesn't match directory!)
 endif
@@ -22,3 +13,12 @@ endif
 # See build/int-template.mk for the template and why this code has to be duplicated
 include build/int-cn.mk
 include build/int-test.mk
+
+# Sum variables
+INT_SOURCES   := \
+	$(INT_SOURCES_CN) \
+	$(INT_SOURCES_TEST)
+
+INT_OUTPUTS   := \
+	$(INT_OUTPUTS_CN) \
+	$(INT_OUTPUTS_TEST)

--- a/build/int.mk
+++ b/build/int.mk
@@ -1,9 +1,9 @@
 # Static declaration of INT branches available
-INT_BRANCHES  := \
+INT_BRANCHES := \
 	cn \
 	test
 
-INT_DIRS      := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
+INT_DIRS     := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
 
 # Assert that the directories in INT match the constant list
 ifneq ($(INT_BRANCHES), $(INT_DIRS))
@@ -15,10 +15,10 @@ include build/int-cn.mk
 include build/int-test.mk
 
 # Sum variables
-INT_SOURCES   := \
+INT_SOURCES  := \
 	$(INT_SOURCES_CN) \
 	$(INT_SOURCES_TEST)
 
-INT_OUTPUTS   := \
+INT_OUTPUTS  := \
 	$(INT_OUTPUTS_CN) \
 	$(INT_OUTPUTS_TEST)

--- a/build/int.mk
+++ b/build/int.mk
@@ -1,0 +1,22 @@
+
+# Dynamic patching and building for any INT directories present
+INT_BRANCHES  := \
+	cn \
+	test
+
+INT_SOURCES   := \
+	$(INT_SOURCES_CN) \
+	$(INT_SOURCES_TEST)
+
+INT_OUTPUTS   := \
+	$(INT_OUTPUTS_CN) \
+	$(INT_OUTPUTS_TEST)
+
+INT_DIRS      := $(patsubst src/css/int/%,%,$(wildcard src/css/int/*))
+
+# Assert that the directories in INT match the constant list.
+ifneq ($(INT_BRANCHES), $(INT_DIRS))
+	$(error Declared list of branches doesn't match directory!)
+endif
+
+# See build/int-template.mk for the template and why this code has to be duplicated

--- a/build/int.mk
+++ b/build/int.mk
@@ -20,3 +20,5 @@ ifneq ($(INT_BRANCHES), $(INT_DIRS))
 endif
 
 # See build/int-template.mk for the template and why this code has to be duplicated
+include build/int-cn.mk
+include build/int-test.mk

--- a/build/legacy.mk
+++ b/build/legacy.mk
@@ -1,6 +1,16 @@
-
+# Variables
 LEGACY_CSS_SOURCES :=
 LEGACY_CSS_OUTPUTS := \
 	dist/stable/styles/DEPRECATED \
 	dist/stable/styles/black-highlighter.min.css \
 	dist/stable/styles/normalize.min.css
+
+# Legacy symlinks for stable/styles CSS
+dist/stable/styles/DEPRECATED: src/misc/legacy-deprecation-notice.txt
+	install -D -m444 $< $@
+
+dist/stable/styles/black-highlighter.min.css:
+	cd $(@D); ln -sf ../../css/min/$(@F)
+
+dist/stable/styles/normalize.min.css:
+	cd $(@D); ln -sf ../../css/min/$(@F)

--- a/build/legacy.mk
+++ b/build/legacy.mk
@@ -1,0 +1,6 @@
+
+LEGACY_CSS_SOURCES :=
+LEGACY_CSS_OUTPUTS := \
+	dist/stable/styles/DEPRECATED \
+	dist/stable/styles/black-highlighter.min.css \
+	dist/stable/styles/normalize.min.css

--- a/build/legacy.mk
+++ b/build/legacy.mk
@@ -1,5 +1,6 @@
 # Variables
-LEGACY_CSS_SOURCES :=
+LEGACY_CSS_SOURCES := \
+	src/misc/legacy-deprecation-notice.txt
 LEGACY_CSS_OUTPUTS := \
 	dist/stable/styles/DEPRECATED \
 	dist/stable/styles/black-highlighter.min.css \

--- a/build/meta.mk
+++ b/build/meta.mk
@@ -1,3 +1,13 @@
+# Variables
 BUILD_SOURCES := \
 	$(wildcard build/**/*) \
 	cssnano.config.js
+
+# Directory creation
+dist/%/:
+	mkdir -p $@
+
+# npm rules
+node_modules: package.json package-lock.json
+	npm install
+	touch node_modules

--- a/build/meta.mk
+++ b/build/meta.mk
@@ -1,0 +1,3 @@
+BUILD_SOURCES := \
+	$(wildcard build/**/*) \
+	cssnano.config.js


### PR DESCRIPTION
This PR splits out Makefiles into separate files based on task type. It additionally explicitly lays out rules for INT variants, as the dynamic approach did not allow make to infer prerequisites.

