### PR TITLE
Add prefixer to merge step

### DIFF
--- a/build/css-merge/postcss.config.js
+++ b/build/css-merge/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: [
     require('postcss-import'),
+    require('autoprefixer'),
   ],
 };


### PR DESCRIPTION
Fixes #72 

This adds prefixes during the merge step, to ensure the full version has them in addition to the minified version. The minified version retains the prefix setting so they are not lost in that step.