### PR TITLE
Use universal install wrapper for all platforms

### DIFF
--- a/build/files.mk
+++ b/build/files.mk
@@ -12,7 +12,7 @@ FILES_OUTPUTS := \
 package-lock.json:
 
 dist/spherical/domicile.html: src/misc/domicile.html
-	install -D -m644 $< $@
+	build/install.sh 644 $< $@
 
 dist/%.html: src/root/%.html
-	install -D -m644 $< $@
+	build/install.sh 644 $< $@

--- a/build/install.sh
+++ b/build/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eu
+
+# Version of "install -D -mXXX" which works even if the -D option isn't supported.
+
+if [[ $# -ne 3 ]]; then
+	echo >&2 "Usage: $0 <mode> <source> <dest>"
+	exit 1
+fi
+
+# Arguments
+mode="$1"
+src="$2"
+dest="$3"
+
+# Derived values
+directory="${dest%/*}"
+
+mkdir -p "$directory"
+install -m"$mode" "$src" "$dest"

--- a/build/int-patch-and-merge.sh
+++ b/build/int-patch-and-merge.sh
@@ -66,7 +66,7 @@ cat \
 
 # Export finished files
 echo "+ Exporting black-highlighter.css"
-install -D -m644 "$tempdir/out/black-highlighter.css" "dist/css/int/$lang/black-highlighter.css"
+build/install.sh 644 "$tempdir/out/black-highlighter.css" "dist/css/int/$lang/black-highlighter.css"
 
 echo "+ Exporting normalize.css"
-install -D -m644 "$tempdir/out/normalize.css" "dist/css/int/$lang/normalize.css"
+build/install.sh 644 "$tempdir/out/normalize.css" "dist/css/int/$lang/normalize.css"

--- a/build/legacy.mk
+++ b/build/legacy.mk
@@ -8,7 +8,7 @@ LEGACY_CSS_OUTPUTS := \
 
 # Legacy symlinks for stable/styles CSS
 dist/stable/styles/DEPRECATED: src/misc/legacy-deprecation-notice.txt
-	install -D -m444 $< $@
+	build/install.sh 444 $< $@
 
 dist/stable/styles/black-highlighter.min.css:
 	cd $(@D); ln -sf ../../css/min/$(@F)

--- a/build/scp-test.mk
+++ b/build/scp-test.mk
@@ -8,10 +8,10 @@ SCP_TEST_OUTPUTS := \
 
 # Copy and inline-patch files
 dist/scp-test-page.html: src/scp-test-page.html
-	install -D -m644 $< $@
+	build/install.sh 644 $< $@
 	sed -i 's|\./scp-test-page.js|/Black-Highlighter/scp-test-page.js|' $@
 
 dist/scp-test-page.js: src/scp-test-page.js
-	install -D -m644 $< $@
+	build/install.sh 644 $< $@
 	sed -i 's|\./css|/Black-Highlighter/css|' $@
 


### PR DESCRIPTION
Darwin `install` does not support the `-D` flag, so this script does `mkdir -p` instead.