### PR TITLE
Use universal sed wrapper for all platforms

### DIFF
--- a/build/install.sh
+++ b/build/install.sh
@@ -16,5 +16,6 @@ dest="$3"
 # Derived values
 directory="${dest%/*}"
 
+# Execution
 mkdir -p "$directory"
 install -m"$mode" "$src" "$dest"

--- a/build/scp-test.mk
+++ b/build/scp-test.mk
@@ -9,9 +9,9 @@ SCP_TEST_OUTPUTS := \
 # Copy and inline-patch files
 dist/scp-test-page.html: src/scp-test-page.html
 	build/install.sh 644 $< $@
-	sed -i 's|\./scp-test-page.js|/Black-Highlighter/scp-test-page.js|' $@
+	build/sed.sh 's|\./scp-test-page.js|/Black-Highlighter/scp-test-page.js|' $@
 
 dist/scp-test-page.js: src/scp-test-page.js
 	build/install.sh 644 $< $@
-	sed -i 's|\./css|/Black-Highlighter/css|' $@
+	build/sed.sh 's|\./css|/Black-Highlighter/css|' $@
 

--- a/build/sed.sh
+++ b/build/sed.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eu
+
+# Version of "sed -i" which works even if the standalone -i option isn't supported.
+
+if [[ $# -ne 2 ]]; then
+	echo >&2 "Usage: $0 <pattern> <file>"
+	exit 1
+fi
+
+# Arguments
+pattern="$1"
+file="$2"
+
+# Temporary file
+temp="$(mktemp /tmp/bhl-XXXXXXXXX)"
+
+on_exit() {
+	rm -f "$temp"
+}
+
+trap on_exit EXIT SIGTERM SIGINT
+
+# Execution
+sed "$pattern" "$file" > "$temp"
+mv "$temp" "$file"


### PR DESCRIPTION
Similar to #86, this PR adds a wrapper for inline sed which works on Mac, which does not support normal GNU `sed -i` invocation.