### PR TITLE
Don't optimize images in icon directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ include build/scp-test.mk
 
 # Top-level rules
 css: dist/css/min/ $(CSS_OUTPUTS) $(INT_OUTPUTS)
-images: dist/img/ $(IMAGE_OUTPUTS)
+images: dist/img/ $(IMAGE_PLAIN_OUTPUTS) $(IMAGE_OPTIMIZE_OUTPUTS)
 files: $(FILES_OUTPUTS)
 scp-test: $(SCP_TEST_OUTPUTS)
 legacy: dist/stable/styles/ $(LEGACY_CSS_OUTPUTS)

--- a/build/images.mk
+++ b/build/images.mk
@@ -1,8 +1,12 @@
-# Variables
-IMAGE_SOURCES := $(wildcard src/img/*)
-IMAGE_OUTPUTS := $(patsubst src/img/%,dist/img/%,$(IMAGE_SOURCES))
+# Image files to run the optimizer on
+IMAGE_OPTIMIZE_SOURCES := $(wildcard src/img/*.*)
+IMAGE_OPTIMIZE_OUTPUTS := $(patsubst src/img/%,dist/img/%,$(IMAGE_OPTIMIZE_SOURCES))
 
-# Image optimization
+# Image files to copy as-is
+IMAGE_PLAIN_SOURCES    := $(wildcard src/img/page-toolbar-icons/* src/img/text-editor-icons/*)
+IMAGE_PLAIN_OUTPUTS    := $(patsubst src/img/%,dist/img/%,$(IMAGE_PLAIN_SOURCES))
+
+# Image optimization rules
 dist/img/%.gif: src/img/%.gif node_modules
 	npm run optimize -- gif $< $@
 
@@ -11,3 +15,7 @@ dist/img/%.png: src/img/%.png node_modules
 
 dist/img/%.svg: src/img/%.svg node_modules
 	npm run optimize -- svg $< $@
+
+# Image copy rule
+dist/img/%: src/img/%
+	build/install.sh 644 $< $@


### PR DESCRIPTION
This adds new rules to copy images statically without running the optimizer on them, since they are not going to be exported to dist. (Here they are still copied to expose them, but they are used directly in the CSS as data URIs so optimizing file outputs doesn't make sense).