### PR TITLE
Add styling for new Interwiki

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -41,6 +41,11 @@ body {
 		100% var(--background-gradient-distance);
 }
 
+/* Remove background image for interwiki */
+#interwiki body {
+	background-image: none;
+}
+
 /* Diagonal Stripes in Header */
 div#container-wrap {
 	background-image: var(--diagonal-stripes);

--- a/src/css/normalize.css
+++ b/src/css/normalize.css
@@ -444,6 +444,7 @@ a {
 
 a,
 #side-bar a:visited,
+#interwiki a:visited,
 a:visited,
 a.newpage {
 	color: inherit;
@@ -797,12 +798,14 @@ sup,
 }
 
 #side-bar,
-#side-bar .side-block {
+#side-bar .side-block,
+#interwiki .side-block {
 	padding: inherit;
 	border: inherit;
 }
 
-#side-bar .side-block {
+#side-bar .side-block,
+#interwiki .side-block {
 	margin-bottom: inherit;
 	-webkit-border-radius: inherit;
 	border-radius: inherit;
@@ -815,7 +818,8 @@ sup,
 	padding: inherit;
 }
 
-#side-bar .heading {
+#side-bar .heading,
+#interwiki .heading {
 	margin-top: inherit;
 	margin-bottom: inherit;
 	padding-left: inherit;
@@ -826,11 +830,14 @@ sup,
 }
 
 #side-bar p,
-#side-bar div.menu-item {
+#side-bar div.menu-item,
+#interwiki p,
+#interwiki div.menu-item {
 	margin: inherit;
 }
 
-#side-bar div.menu-item img {
+#side-bar div.menu-item img,
+#interwiki div.menu-item img {
 	position: inherit;
 	bottom: inherit;
 	width: inherit;
@@ -839,7 +846,8 @@ sup,
 	border: inherit;
 }
 
-#side-bar div.menu-item a {
+#side-bar div.menu-item a,
+#interwiki div.menu-item a {
 	font-weight: inherit;
 }
 

--- a/src/css/root.css
+++ b/src/css/root.css
@@ -442,7 +442,8 @@
 	--dropdown-links-hover-bg-color: var(--swatch-primary);
 }
 
-#side-bar {
+#side-bar,
+#interwiki {
 	/* ===SIDE-BAR ELEMENTS=== */
 
 		/* ===SIDE-BAR GENERAL=== */

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -543,24 +543,29 @@
 	text-decoration: none;
 }
 
-/* Interwiki Styling specifically not targeting CN Branch, which already has a BHL interwiki */
+/* Interwiki styling for Interwikis that cannot style themselves. Also targets the SCP-CN Interwiki, which is stylable but does not currently have the interwiki-stylable class */
 #side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)),
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) * {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) *,
+#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable),
+#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) * {
 	max-width: var(--sidebar-width-on-desktop);
 }
 
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)),
+#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) {
 	position: relative;
 }
 
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) div.list-pages-item {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) div.list-pages-item,
+#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) div.list-pages-item {
 	display: flex;
 	align-items: flex-end;
 	justify-content: flex-end;
 	width: 100%;
 }
 
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) p {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) p,
+#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) p {
 	display: flex;
 	position: relative;
 	align-items: center;
@@ -569,7 +574,8 @@
 	overflow: hidden;
 }
 
-#side-bar iframe.scpnet-interwiki-frame:not(:lang(cn)) {
+#side-bar iframe.scpnet-interwiki-frame:not(:lang(cn)),
+#side-bar iframe.scpnet-interwiki-frame:not(.interwiki-stylable) {
 	position: relative;
 	width: 90%;
 	margin: 0 auto;
@@ -580,7 +586,10 @@
 @supports(mix-blend-mode:hue) {
 	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn))::before,
 	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::before,
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::after {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::after,
+	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable)::before,
+	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::before,
+	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::after {
 		content: "";
 		position: absolute;
 		top: 0;
@@ -590,19 +599,22 @@
 		pointer-events: none;
 	}
 
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn))::before {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn))::before,
+	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable)::before {
 		z-index: 3;
 		background-color: rgb(var(--swatch-menubg-color));
 		mix-blend-mode: darken;
 	}
 
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::before {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::before,
+	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::before {
 		z-index: 2;
 		background-color: rgb(var(--swatch-primary));
 		mix-blend-mode: color;
 	}
 
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::after {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::after,
+	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::after {
 		z-index: 1;
 		transition: background-color 500ms cubic-bezier(.4,0,.2,1);
 		background-color: rgb(var(--swatch-menubg-color));

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -610,6 +610,11 @@
 	}
 }
 
+/* Remove margin around stylable interwiki */
+#side-bar .interwiki-stylable p {
+	margin: 0;
+}
+
 /* Collapsibles in the sidebar */
 
 #side-bar div.collapsible-block {

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -543,7 +543,7 @@
 	text-decoration: none;
 }
 
-/* Interwiki Styling specifically not targetting CN Branch */
+/* Interwiki Styling specifically not targeting CN Branch, which already has a BHL interwiki */
 #side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)),
 #side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) * {
 	max-width: var(--sidebar-width-on-desktop);

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -544,28 +544,23 @@
 }
 
 /* Interwiki styling for Interwikis that cannot style themselves. Also targets the SCP-CN Interwiki, which is stylable but does not currently have the interwiki-stylable class */
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)),
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) *,
-#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable),
-#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) * {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable),
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) * {
 	max-width: var(--sidebar-width-on-desktop);
 }
 
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)),
-#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) {
 	position: relative;
 }
 
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) div.list-pages-item,
-#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) div.list-pages-item {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) div.list-pages-item {
 	display: flex;
 	align-items: flex-end;
 	justify-content: flex-end;
 	width: 100%;
 }
 
-#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)) p,
-#side-bar div.scpnet-interwiki-wrapper:not(.interwiki-stylable) p {
+#side-bar div.scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) p {
 	display: flex;
 	position: relative;
 	align-items: center;
@@ -574,8 +569,7 @@
 	overflow: hidden;
 }
 
-#side-bar iframe.scpnet-interwiki-frame:not(:lang(cn)),
-#side-bar iframe.scpnet-interwiki-frame:not(.interwiki-stylable) {
+#side-bar iframe.scpnet-interwiki-frame:not(:lang(cn)):not(.interwiki-stylable) {
 	position: relative;
 	width: 90%;
 	margin: 0 auto;
@@ -584,12 +578,9 @@
 
 /* Coloring to (mostly) match sidebar */
 @supports(mix-blend-mode:hue) {
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn))::before,
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::before,
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::after,
-	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable)::before,
-	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::before,
-	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::after {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable)::before,
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) p::before,
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) p::after {
 		content: "";
 		position: absolute;
 		top: 0;
@@ -599,22 +590,19 @@
 		pointer-events: none;
 	}
 
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn))::before,
-	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable)::before {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable)::before {
 		z-index: 3;
 		background-color: rgb(var(--swatch-menubg-color));
 		mix-blend-mode: darken;
 	}
 
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::before,
-	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::before {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) p::before {
 		z-index: 2;
 		background-color: rgb(var(--swatch-primary));
 		mix-blend-mode: color;
 	}
 
-	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)) p::after,
-	#side-bar .scpnet-interwiki-wrapper:not(.interwiki-stylable) p::after {
+	#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) p::after {
 		z-index: 1;
 		transition: background-color 500ms cubic-bezier(.4,0,.2,1);
 		background-color: rgb(var(--swatch-menubg-color));

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -213,7 +213,8 @@
 /* ===SUB-BLOCK=== */
 #side-bar .side-block,
 #side-bar div[style*="center"],
-#side-bar div[style*="center"] > div {
+#side-bar div[style*="center"] > div,
+#interwiki .side-block {
 	display: grid;
 	grid-template-rows: repeat(auto-fit, minmax(1.3125rem, 1fr));
 }
@@ -225,7 +226,8 @@
 	width: 100%;
 }
 
-#side-bar .side-block {
+#side-bar .side-block,
+#interwiki .side-block {
 	margin: 0.5rem 0.5rem 0 0;
 	border: 0;
 	background: rgb(var(--sideblock-bg-color));
@@ -237,7 +239,8 @@
 }
 
 /* ===HEADING=== */
-#side-bar .heading {
+#side-bar .heading,
+#interwiki .heading {
 	display: flex;
 	align-items: flex-end;
 	justify-content: flex-start;
@@ -246,11 +249,13 @@
 	box-shadow: 0 0.0625rem 0 0 rgb(var(--sideblock-heading-border-color));
 }
 
-#side-bar .heading {
+#side-bar .heading,
+#interwiki .heading {
 	background-color: rgb(var(--sideblock-heading-bg-color));
 }
 
-#side-bar .heading p {
+#side-bar .heading p,
+#interwiki .heading p {
 	--wght: calc(var(--ui-wght) + 300);
 	margin: 0;
 	color: rgb(var(--sideblock-heading-text-color));
@@ -263,13 +268,16 @@
 	text-transform: uppercase;
 }
 
-#side-bar .heading p {
+#side-bar .heading p,
+#interwiki .heading p {
 	cursor: default;
 }
 
 /* ===MENU ITEMS=== */
 #side-bar div.menu-item,
-#side-bar div.menu-item > p {
+#side-bar div.menu-item > p,
+#interwiki div.menu-item,
+#interwiki div.menu-item > p {
 	display: flex;
 	flex-basis: 100%;
 	flex-flow: row wrap;
@@ -286,16 +294,21 @@
 }
 
 #side-bar div.menu-item p::before,
-#side-bar div.menu-item p::after {
+#side-bar div.menu-item p::after,
+#interwiki div.menu-item p::before,
+#interwiki div.menu-item p::after {
 	display: none;
 }
 
 #side-bar div.menu-item > span,
-#side-bar div.menu-item > p > span {
+#side-bar div.menu-item > p > span,
+#interwiki div.menu-item > span,
+#interwiki div.menu-item > p > span {
 	display: none;
 }
 
-#side-bar div.menu-item span:first-of-type {
+#side-bar div.menu-item span:first-of-type,
+#interwiki div.menu-item span:first-of-type {
 	padding: 0 0 0 calc((var(--base-font-size) * 1.5));
 }
 	/* ===SUB-TEXT=== */
@@ -311,7 +324,8 @@
 }
 
 	/* ===MAIN LINKS & TEXT=== */
-#side-bar div.menu-item a {
+#side-bar div.menu-item a,
+#interwiki div.menu-item a {
 	position: relative;
 	z-index: 2;
 	height: inherit;
@@ -319,7 +333,9 @@
 }
 
 #side-bar div.menu-item a,
-#side-bar div.menu-item a:visited {
+#side-bar div.menu-item a:visited,
+#interwiki div.menu-item a,
+#interwiki div.menu-item a:visited {
 	--wght: var(--ui-wght);
 	display: flex;
 	flex-grow: 2;
@@ -364,7 +380,8 @@
 	cursor: default;
 }
 
-#side-bar div.menu-item a:only-child {
+#side-bar div.menu-item a:only-child,
+#interwiki div.menu-item a:only-child {
 	flex-grow: 1;
 }
 
@@ -373,17 +390,21 @@
 	border-left: 0.125rem solid rgba(var(--sidebar-border-color));
 }
 
-#side-bar div.menu-item > :last-child {
+#side-bar div.menu-item > :last-child,
+#interwiki div.menu-item > :last-child {
 	flex-grow: 2;
 }
 
-#side-bar div.menu-item a {
+#side-bar div.menu-item a,
+#interwiki div.menu-item a {
 	justify-content: flex-start;
 	padding: 0 0 0 calc(var(--base-font-size) * (14 / 15));
 }
 
 #side-bar div.menu-item a:hover,
-#side-bar div.menu-item a:active {
+#side-bar div.menu-item a:active,
+#interwiki div.menu-item a:hover,
+#interwiki div.menu-item a:active {
 	--wght: var(--ui-hvr-wght);
 	background-color: rgba(var(--sidebar-links-hover-bg-color), 0.15);
 	color: rgb(var(--sidebar-links-hover-text-color));
@@ -391,7 +412,8 @@
 	text-decoration: none;
 }
 
-#side-bar div.menu-item a:focus-within {
+#side-bar div.menu-item a:focus-within,
+#interwiki div.menu-item a:focus-within {
 	--wght: var(--ui-hvr-wght);
 	background-color: rgba(var(--sidebar-links-hover-bg-color), 0.15);
 	color: rgb(var(--sidebar-links-hover-text-color));
@@ -401,7 +423,8 @@
 
 	/* ===MAIN LINKS HOVER BG BAR=== */
 	/* Menu Item Hover Color Bar */
-#side-bar div.menu-item a::before {
+#side-bar div.menu-item a::before,
+#interwiki div.menu-item a::before {
 	--clip-path: 
 		polygon(
 			0 0, 
@@ -424,7 +447,9 @@
 }
 
 #side-bar div.menu-item a:hover::before,
-#side-bar div.menu-item a:active::before {
+#side-bar div.menu-item a:active::before,
+#interwiki div.menu-item a:hover::before,
+#interwiki div.menu-item a:active::before {
 	--clip-path: 
 		polygon(
 			-15% 0, 
@@ -434,7 +459,8 @@
 		);
 }
 
-#side-bar div.menu-item a:focus-within::before {
+#side-bar div.menu-item a:focus-within::before,
+#interwiki div.menu-item a:focus-within::before {
 	--clip-path: 
 		polygon(
 			-15% 0, 
@@ -463,6 +489,7 @@
 }
 
 #side-bar div.menu-item img,
+#interwiki div.menu-item img,
 #side-bar div.menu-item br {
 	display: none;
 }

--- a/src/css/sidebar.css
+++ b/src/css/sidebar.css
@@ -569,7 +569,7 @@
 	overflow: hidden;
 }
 
-#side-bar iframe.scpnet-interwiki-frame:not(:lang(cn)):not(.interwiki-stylable) {
+#side-bar .scpnet-interwiki-wrapper:not(:lang(cn)):not(.interwiki-stylable) iframe.scpnet-interwiki-frame {
 	position: relative;
 	width: 90%;
 	margin: 0 auto;


### PR DESCRIPTION
This PR will add new interwiki styling to BHL. I intend for the new interwiki to be styled for BHL by importing first the normaliser and then BHL itself, just like how everything else is styled on Sigma-9 based sites. This should result in minimal changes being needed - just a few more selectors added here and there.

The new interwiki as of scpwiki/interwiki#3 has the following structure:

```css
html#interwiki
  div.side-block
    div.heading          (once)
      p
    div.menu-item[name]  (repeats)
      img.image a
```
To target elements in the new interwiki, selectors like `#interwiki div.menu-item` should be applied. This looks similar to `#side-bar div.menu-item`, which could give the impression that `#side-bar` and `#interwiki` refer to similar elements (but they don't).

There's a bunch of CSS in BHL that applies to the sidebar and the sidebar wrapper, especially with regards to CN (which worries me because CN is currently using a new-style interwiki). I'm not totally sure how any new CSS here should intersect with it - I might need your help with that.

- [x] Add interwiki to the normaliser, based on scpwiki/sigma9#42
- [x] Extend sidebar styling to interwiki
- [x] Extend old interwiki styling to new interwiki
- [x] Apply variables that target the sidebar to target the interwiki, where appropriate
- [x] Test it

Handy command for resolving the font imports when using a test deployment to a flat structure (by e.g. uploading an output file to wikidot):

```sh
make clean && make && sed "s|../fonts/fonts.css|https://nu-scptheme.github.io/Black-Highlighter/fonts/fonts.css|" dist/css/black-highlighter.css -i
```