### PR TITLE
Update structure.css

### DIFF
--- a/src/css/structure.css
+++ b/src/css/structure.css
@@ -1299,6 +1299,7 @@ h4,
 h5,
 h6 {
 	margin: 0 0 0.5em 0;
+	padding: 0;
 	font-family: var(--title-font);
 	font-weight: revert;
 	line-height: 1.4;


### PR DESCRIPTION
The only padding that h1 through h6 elements have in BHL right now is `padding: inherit`, which they gain from normalize.css. This means that when one of those elements is placed inside of a div, it gains the padding of the div. When not in a div, it has no padding. This causes an odd amount of extra space on such elements while in divs compared to when they are normally placed on a page. This change adds a `padding: 0` argument to the elements, so they have a consistent appearance wherever they are placed in an article.