### PR TITLE
remove border from .rate-point

### DIFF
--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -756,6 +756,7 @@ div.blockquote> :last-child,
 div.page-rate-widget-box .rate-points {
 	display: flex;
 	padding: 0 0.5em;
+	border: none;
 	background-color: transparent;
 	color: rgb(var(--rating-module-text-color));
 	font-family: var(--UI-font);


### PR DESCRIPTION
Remove border around .rate-points due to normalize.css setting to inherit.