### PR TITLE
Adding fonts.css to the import

### DIFF
--- a/build/css.mk
+++ b/build/css.mk
@@ -10,7 +10,7 @@ dist/css/black-highlighter.css: src/css/black-highlighter.css $(BUILD_SOURCES) $
 
 dist/css/min/black-highlighter.min.css: dist/css/black-highlighter.css node_modules
 	npm run postcss -- --no-map --use cssnano -o $@ $<
-	build/sed.sh 's|\.\./fonts/fonts\.css|../../fonts/fonts.css|' $@
+	build/sed.sh 's|\.\./fonts|../../fonts|g' $@
 
 dist/css/normalize.css: src/css/normalize.css $(BUILD_SOURCES)
 	cp -f $< $@

--- a/build/postcss.config.js
+++ b/build/postcss.config.js
@@ -1,6 +1,14 @@
 module.exports = {
   plugins: [
-    require('postcss-import')({filter: url => url !== "../fonts/fonts.css"}),
+    require('postcss-import'),
+    require('postcss-path-replace')
+    (
+      {
+        publicPath: "../fonts/",
+        matched: "./",
+        mode: "replace"
+      }
+    ),
     require('autoprefixer'),
     require('postcss-preset-env')({stage: 1}),
     require("@hail2u/css-mqpacker"),

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "postcss": "^8.4.21",
     "postcss-cli": "^10.1.0",
     "postcss-import": "^15.1.0",
+    "postcss-path-replace": "^1.0.4",
     "postcss-preset-env": "^7.8.3",
     "prettier": "2.8.3",
     "stylelint": "^14.16.1",

--- a/src/css/black-highlighter.css
+++ b/src/css/black-highlighter.css
@@ -1,3 +1,5 @@
+@charset "utf-8";
+@import "../fonts/fonts.css";
 @import "./root.css";
 @import "./int/root.int.css";
 @import "./encoded-svgs.css";

--- a/src/css/root.css
+++ b/src/css/root.css
@@ -1,6 +1,3 @@
-@charset "utf-8";
-@import "../fonts/fonts.css";
-
 /* ROOT VARS
    ============================= */
 


### PR DESCRIPTION
In order to speed up loading of the theme css file, the fonts.css file which includes all the `@font-face` rules is set to also be imported into the main CSS files.

In order to do so, the relative src links needed to be replaced via PostCSS and a global `sed` command on the css.mk file.