### PR TITLE
change margin to gap properties

### DIFF
--- a/src/css/wikidot-structure.css
+++ b/src/css/wikidot-structure.css
@@ -509,6 +509,7 @@ div[id*="page-options-bottom"] {
 	flex-wrap: wrap;
 	align-items: center;
 	justify-content: center;
+	gap: 1ch;
 	width: 100%;
 	max-width: min(90vw, var(--body-width-on-desktop));
 	font-family: var(--UI-font);
@@ -524,7 +525,6 @@ div[id*="page-options-bottom"]:not(.page-rate-widget-box):not(#search-top-box-fo
 	--button-padding: calc(var(--icon-size) / 8);
 	flex-basis: 5rem;
 	height: 1.5em;
-	margin: 0 0.5ch 1ch 0.5ch;
 	padding: var(--button-padding);
 	padding-left: calc(var(--icon-size) + 0.5em);
 	box-shadow:


### PR DESCRIPTION
It's more optimal to use the gap propety here instead o using margin to create spaces.