### PR TITLE
correct mobile left margin for h1,h2

### DIFF
--- a/src/css/parts/header.css
+++ b/src/css/parts/header.css
@@ -1173,6 +1173,7 @@ div#container-wrap {
 
 			& a {
 				margin-top: calc(((var(--header-height-on-mobile) / 2)) - 1.345rem);
+				margin-left: calc(var(--header-height-on-mobile) - .625rem);
 			}
 
 			& span {
@@ -1183,6 +1184,7 @@ div#container-wrap {
 		& h2 {
 			& span {
 				margin-top: calc(((var(--header-height-on-mobile) / 2) + (var(--header-h1-font-size) / 2) + 0.5rem));
+				margin-left: calc(var(--header-height-on-mobile) - .425rem);
 				line-height: 1;
 			}
 		}


### PR DESCRIPTION
#header h1 a, h2 span does not repect mobile header height.