### PR TITLE
center-align text in the save modal

### DIFF
--- a/src/css/parts/wikidot-structure.css
+++ b/src/css/parts/wikidot-structure.css
@@ -3853,6 +3853,7 @@ div.odialog-shader-iframe {
 		}
 
 		&.owait .content {
+			text-align: center;
 			padding: 0.5em 0.5em 2em;
 			background-image: none;
 


### PR DESCRIPTION
Text is not centered for the save .owindow

![image](https://github.com/Nu-SCPTheme/Black-Highlighter/assets/93550009/2c28fa19-72f4-4740-987c-81d122b9af67)
