### PR TITLE
Set up Black Higlighter to deploy to cdn.scpwiki.com

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Deploy (S3)
         uses: jakejarvis/s3-sync-action@master
-        #if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           args: --delete
         env:
@@ -69,7 +69,7 @@ jobs:
 
       - name: Invalidate CloudFront
         uses: chetan/invalidate-cloudfront-action@v2
-        #if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         env:
           DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION }}
           PATHS: /theme/en/black-highlighter

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: 'Build'
+name: Deploy
 on:
   push:
     paths:
@@ -44,9 +44,30 @@ jobs:
       - name: Build
         run: make
 
-      - name: Deploy
+      - name: Deploy (GitHub Pages)
         uses: JamesIves/github-pages-deploy-action@4.1.4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           branch: gh-pages
           folder: dist
+
+      - name: Deploy (S3)
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: dist
+          DEST_DIR: theme/en/black-highlighter
+
+      - name: Invalidate CloudFront
+        uses: chetan/invalidate-cloudfront-action@v2
+        env:
+          DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION }}
+          PATHS: /theme/en/black-highlighter
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,6 +51,9 @@ jobs:
           branch: gh-pages
           folder: dist
 
+      - name: Clean up for S3
+        run: make clean-up-s3
+
       - name: Deploy (S3)
         uses: jakejarvis/s3-sync-action@master
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Deploy (S3)
         uses: jakejarvis/s3-sync-action@master
-        if: ${{ github.ref == 'refs/heads/master' }}
+        #if: ${{ github.ref == 'refs/heads/master' }}
         with:
           args: --delete
         env:
@@ -69,7 +69,7 @@ jobs:
 
       - name: Invalidate CloudFront
         uses: chetan/invalidate-cloudfront-action@v2
-        if: ${{ github.ref == 'refs/heads/master' }}
+        #if: ${{ github.ref == 'refs/heads/master' }}
         env:
           DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION }}
           PATHS: /theme/en/black-highlighter

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Deploy (S3)
         uses: jakejarvis/s3-sync-action@master
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           args: --delete
         env:
@@ -68,6 +69,7 @@ jobs:
 
       - name: Invalidate CloudFront
         uses: chetan/invalidate-cloudfront-action@v2
+        if: ${{ github.ref == 'refs/heads/master' }}
         env:
           DISTRIBUTION: ${{ secrets.CF_DISTRIBUTION }}
           PATHS: /theme/en/black-highlighter

--- a/build/files.mk
+++ b/build/files.mk
@@ -25,4 +25,4 @@ dist/%.html: src/root/%.html
 
 # Special rule, delete anything not meant for S3
 clean-up-s3:
-	rm -rf dist/spherical dist/.gitattributes dist/*.html
+	rm -rf dist/spherical dist/.gitattributes dist/*.html dist/*.js

--- a/build/files.mk
+++ b/build/files.mk
@@ -13,6 +13,7 @@ FILES_OUTPUTS := \
 # Dummy rules
 pnpm-lock.yaml:
 
+# File copy
 dist/spherical/domicile.html: src/misc/domicile.html
 	build/install.sh 644 $< $@
 
@@ -21,3 +22,7 @@ dist/.gitattributes: src/misc/gitattributes
 
 dist/%.html: src/root/%.html
 	build/install.sh 644 $< $@
+
+# Special rule, delete anything not meant for S3
+clean-up-s3:
+	rm -rf dist/spherical dist/.gitattributes dist/*.html


### PR DESCRIPTION
This is the second use of `cdn.scpwiki.com` to serve theme content, see https://github.com/scpwiki/sigma/pull/81. This will be a nice, permanent solution to GitHub being blocked in various places, thus preventing people from being able to load theme data. The idea with these changes is that this CDN will be our new place for BHL asset hosting, though we will continue to push to GitHub pages as there may be unseen consumers relying on it.

The location for files will be under `/theme/en/black-highlighter/`, for instance:
* https://cdn.scpwiki.com/theme/en/black-highlighter/css/black-highlighter.css
* https://cdn.scpwiki.com/theme/en/black-highlighter/css/black-highlighter.min.css
* https://cdn.scpwiki.com/theme/en/black-highlighter/fonts/int/japanese/m-plus-1p-v19-japanese-500.ttf