### PR TITLE
Remove a deprecated "supports"

### DIFF
--- a/src/css/parts/elements.css
+++ b/src/css/parts/elements.css
@@ -976,10 +976,6 @@ div.heritage-rating-module {
 				}
 			}
 		}
-
-		@supports not (scale: 2 1) {
-			transform: scale(2, 1);
-		}
 	}
 
 	& div.creditBottomRate {


### PR DESCRIPTION
Since the `scale: 2 1` has removed by SYwaves in #215 , we should remove the corresponding `@supports not (scale: 2 1)`.