### PR TITLE
Remove flow-root supports

### DIFF
--- a/src/css/parts/elements.css
+++ b/src/css/parts/elements.css
@@ -199,7 +199,7 @@
 /* ===BLOCKQUOTE=== */
 
 :is(blockquote, .blockquote, div.blockquote, [class*="blockquote"]) {
-	display: block;
+	display: flow-root;
 	position: relative;
 	margin-block: 1ex 0;
 	margin-inline: 2ch;
@@ -215,10 +215,6 @@
 
 	&:last-child:not(:only-child) {
 		margin-block-end: 1em;
-	}
-
-	@supports (display: flow-root) {
-		display: flow-root;
 	}
 }
 


### PR DESCRIPTION
`display: flow-root` has browser support at over 96% according to caniuse, so the @supports can be removed, IMO. Alternatively, add display: block before display: flow-root to do the same thing slightly more compactly.