### PR TITLE
Namespacing all @keyframes with bhl-

### DIFF
--- a/src/css/parts/elements.css
+++ b/src/css/parts/elements.css
@@ -384,7 +384,7 @@ a.math-equation-error {
 	z-index: 100;
 	width: fit-content !important; /* Overwriting JS-injected inline styling */
 	max-width: calc(var(--body-width-on-desktop) - 2rem);
-	animation: fade-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards;
+	animation: bhl-fade-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards;
 	border: none !important; /* Overwriting JS-injected inline styling */
 	opacity: 0;
 	background-color: rgb(var(--hoverblock-bg)) !important; /* Overwriting JS-injected inline styling */
@@ -400,7 +400,7 @@ a.math-equation-error {
 		height: 100%;
 		margin: 0;
 		padding: 0;
-		animation: lift-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards, slide-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards;
+		animation: bhl-lift-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards, bhl-slide-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards;
 		background-color: transparent;
 		box-shadow: 0 0 0 0 rgba(var(--swatch-alternate-color), 0.25), inset 0 0 0 0.0625rem rgb(var(--swatch-primary-darkest));
 	}
@@ -412,7 +412,7 @@ a.math-equation-error {
 		margin: 0;
 		padding: 0.25em 0.5em;
 		translate: 0 0;
-		animation: slide-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards;
+		animation: bhl-slide-in 0.2s var(--ease-in-out) 0.1s 1 alternate forwards;
 		font-family: var(--UI-font);
 		font-size: 0.9em;
 

--- a/src/css/parts/root.css
+++ b/src/css/parts/root.css
@@ -703,7 +703,7 @@
 	--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-@keyframes fade-in {
+@keyframes bhl-fade-in {
 	from {
 		opacity: 0;
 	}
@@ -713,7 +713,7 @@
 	}
 }
 
-@keyframes slide-in {
+@keyframes bhl-slide-in {
 	from {
 		translate: 1rem 1rem;
 	}
@@ -725,7 +725,7 @@
 
 
 @supports not (translate: 1rem 1rem) {
-	@keyframes slide-in {
+	@keyframes bhl-slide-in {
 		from {
 			transform: translate(1rem, 1rem);
 		}
@@ -736,7 +736,7 @@
 	}
 }
 
-@keyframes slide-down {
+@keyframes bhl-slide-down {
 	from {
 		max-height: 0;
 	}
@@ -746,7 +746,7 @@
 	}
 }
 
-@keyframes lift-in {
+@keyframes bhl-lift-in {
 	from {
 		box-shadow: 0 0 0 0 rgba(var(--swatch-alternate-color), 0.25), inset 0 0 0 0.0625rem rgb(var(--swatch-primary-darkest));
 	}

--- a/src/css/parts/wikidot-structure.css
+++ b/src/css/parts/wikidot-structure.css
@@ -3863,7 +3863,7 @@ div.odialog-shader-iframe {
 				height: 1.5rem;
 				margin: -0.9rem auto;
 				margin-top: 0.6rem;
-				animation: loading 1.2s linear infinite;
+				animation: bhl-loading 1.2s linear infinite;
 				border-top: 0.3rem solid rgb(var(--modal-header-stripe));
 				border-right: 0.3rem solid transparent;
 				border-bottom: 0.3rem solid rgb(var(--modal-header-stripe));
@@ -4257,7 +4257,7 @@ div.odialog-shader-iframe {
 	}
 }
 
-@keyframes loading {
+@keyframes bhl-loading {
 	0% {
 		rotate: 0deg;
 	}
@@ -4268,7 +4268,7 @@ div.odialog-shader-iframe {
 }
 
 @supports not (rotate: 0) {
-	@keyframes loading {
+	@keyframes bhl-loading {
 		0% {
 			transform: rotate(0deg);
 		}


### PR DESCRIPTION
Namepacing the `@keyframes` to prevent conflict/name collision, as seen in https://github.com/Nu-SCPTheme/Black-Highlighter/issues/234#issuecomment-1866062346

On a separate note, which element uses `@keyframes slide-down`? Couldn't find it to mirror the change.