### PR TITLE
adjust #footer .options to use flex

### DIFF
--- a/src/css/parts/wikidot-structure.css
+++ b/src/css/parts/wikidot-structure.css
@@ -617,11 +617,12 @@ div[id*="page-options-bottom"] {
 	white-space: nowrap;
 
 	.options {
-		display: grid !important;
-		grid-template-columns: repeat(9, min-content);
+		display: flex !important;
+		flex-wrap: wrap;
 		align-items: center;
 		justify-content: center;
-		padding: 0 1.5em 0 0;
+		font-size: 0;
+		padding: 0 .25rem 0 0;
 		color: transparent;
 
 		&,
@@ -635,8 +636,10 @@ div[id*="page-options-bottom"] {
 				display: inline-flex;
 				align-items: center;
 				justify-content: center;
-				width: 100%;
 				height: 1em;
+				order: 1;
+				font-size: calc(var(--base-font-size)*.75);
+				padding-right: .4em;
 				box-shadow: 0.0625rem 0 0 0 rgb(var(--swatch-text-secondary-color));
 			}
 		}


### PR DESCRIPTION
Change `#footer .options` to display: flex and allow it to wrap on narrower screen size.

Currently, this can overflow if total width is bigger than available screen width.

Simulated with larger base font size: http://scptestwiki.wikidot.com/sytest3
![image](https://github.com/Nu-SCPTheme/Black-Highlighter/assets/93550009/d0b9ebad-99a2-4e60-9fbc-e51c9727aa35)
