### PR TITLE
fix margin on mobile #content-wrap

### DIFF
--- a/src/css/parts/wikidot-structure.css
+++ b/src/css/parts/wikidot-structure.css
@@ -4382,6 +4382,7 @@ div.odialog-shader-iframe {
 @media (--viewport-tablet) {
 	#content-wrap {
 		grid-template-areas: "content content content";
+		grid-template-columns: minmax(0,1fr) minmax(0,1fr) minmax(0,1fr);
 		justify-content: center;
 		min-height: calc(100vh - var(--final-header-height-on-mobile));
 		margin: calc(var(--topbar-height-on-mobile) - 0.125rem) auto 0 !important;


### PR DESCRIPTION
Fix an issue where `grid-template-columns` in mobile queries are not adjusted, resulting in uneven whitespace on the sides of `#main-content`

![image](https://github.com/Nu-SCPTheme/Black-Highlighter/assets/93550009/cfa73352-c0b4-47cc-8662-43d949b5dc88)
